### PR TITLE
Add support for rails <5.1

### DIFF
--- a/lib/service_logger/version.rb
+++ b/lib/service_logger/version.rb
@@ -1,3 +1,3 @@
 module ServiceLogger
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/service_logger.gemspec
+++ b/service_logger.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'pry-byebug', '~> 3.3'
 
-  spec.add_runtime_dependency 'activesupport', '>= 4', '<= 5.0.0.beta2'
-  spec.add_runtime_dependency 'actionpack', '>= 4', '<= 5.0.0.beta2'
-  spec.add_runtime_dependency 'railties', '>= 4', '<= 5.0.0.beta2'
+  spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
+  spec.add_runtime_dependency 'actionpack', '>= 4', '< 5.1'
+  spec.add_runtime_dependency 'railties', '>= 4', '< 5.1'
 
-  spec.add_runtime_dependency 'lograge', "~> 0.3.6"
+  spec.add_runtime_dependency 'lograge', "~> 0.4.1"
 end


### PR DESCRIPTION
Add support for Rails 5 up to <5.1

- Update `lograge` as a dependency to 0.4.1 to allow support for rails <5.1
- Update `activesupport`, `actiopack` and `railties` to allow support for rails <5.1